### PR TITLE
Reset the file pointer on uploads

### DIFF
--- a/dc/__init__.py
+++ b/dc/__init__.py
@@ -130,6 +130,9 @@ class Dataset(object):
             fh = resource['upload']
             contents = fh.read()
             size = fh.tell()
+            
+            # Reset the file pointer so ckanapi can read the whole file.
+            fh.seek(0)
             checksum = hashlib.md5(contents).hexdigest()
             resource['hash'] = checksum
             resource['size'] = size


### PR DESCRIPTION
When doing uploads, we currently get 0 byte files.  Suspect this may be because we read the file handle fully and then pass it to ckanapi without resetting the handle back to pos 0